### PR TITLE
Split YAML directory builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 /manifests/secret.yaml
+/manifests/k8s/**/*.yaml
+/secrets/**/*.yaml

--- a/builder.sh
+++ b/builder.sh
@@ -4,4 +4,4 @@ bundle exec kuby -e production dockerfiles --only app > manifests/Dockerfile
 bundle exec kuby -e production dockerfiles --only assets > manifests/Dockerfile.assets
 
 # bundle exec kuby -e production resources | minus secrets
-bundle exec ruby split-builder.rb # > outputs to - manifests/k8s.yml
+bundle exec ruby builder.rb # > outputs to - manifests/k8s.yml

--- a/builder.sh
+++ b/builder.sh
@@ -4,4 +4,4 @@ bundle exec kuby -e production dockerfiles --only app > manifests/Dockerfile
 bundle exec kuby -e production dockerfiles --only assets > manifests/Dockerfile.assets
 
 # bundle exec kuby -e production resources | minus secrets
-bundle exec ruby builder.rb # > outputs to - manifests/k8s.yml
+bundle exec ruby split-builder.rb # > outputs to - manifests/k8s.yml

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -22,7 +22,30 @@ module Splat
     mkdirp(path); path
   end
 
+  def abort_if_missing_kind(object)
+    o = object.dig("kind")
+    if o.nil? || (o&.length == 0)
+      raise StandardError,
+        "Kubernetes YAML resources cannot be missing apiVersion or kind"
+    end
+  end
+
+  def abort_if_missing_name(object)
+    o = object.dig("metadata","name")
+    if o.nil? || (o&.length == 0)
+      raise StandardError,
+        "Kubernetes YAML resources cannot be missing metadata.name"
+    end
+  end
+
   def write_namespaces_into_folder(namespaces_arr:, target_dir:)
+    # validate first
+    namespaces_arr.values.flatten.map{|o|
+      abort_if_missing_kind(o)
+      abort_if_missing_name(o)
+    }
+
+    # write everything out into folders
     namespaces_arr.each do |namespace, arr|
       path = safe_path_ref(target_dir:target_dir, namespace:namespace)
 

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -1,6 +1,7 @@
 # typed: strict
 require 'forwardable'
 require 'fileutils'
+require 'yaml'
 
 module Splat
   module_function
@@ -15,9 +16,13 @@ module Splat
       arr.each do |o|
         object_name = o.dig("metadata", "name")
         target_file = File.join(path, "#{object_name}.yaml")
-        File.open(target_file, 'w') { |file| file.write(o.to_yaml) }
+        write_to_file(target_file: target_file, object: o)
       end
     end
+  end
+
+  def write_to_file(target_file:, object:)
+    File.open(target_file, 'w') { |file| file.write(object.to_yaml) }
   end
 end
 

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -1,7 +1,6 @@
 # typed: strict
 require 'forwardable'
-
-# require 'pry'
+require 'fileutils'
 
 module Splat
   module_function

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -1,7 +1,10 @@
 # typed: strict
 require 'forwardable'
 
+require 'pry'
+
 module Splat
+  module_function
   def sort_into_namespaces(arr)
     binding.pry
   end

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -1,16 +1,24 @@
 # typed: strict
 require 'forwardable'
 
-require 'pry'
+# require 'pry'
 
 module Splat
   module_function
   def sort_into_namespaces(arr)
-    binding.pry
+    arr.group_by {|o| o.dig("metadata", "namespace")}
   end
 
   def write_namespaces_into_folder(namespaces_arr:, target_dir:)
-    binding.pry
+    namespaces_arr.each do |namespace, arr|
+      path = File.join(target_dir,namespace)
+      FileUtils.mkdir_p path
+      arr.each do |o|
+        object_name = o.dig("metadata", "name")
+        target_file = File.join(path, "#{object_name}.yaml")
+        File.open(target_file, 'w') { |file| file.write(o.to_yaml) }
+      end
+    end
   end
 end
 

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -51,7 +51,8 @@ module Splat
 
       arr.each do |o|
         object_name = o.dig("metadata", "name")
-        target_file = File.join(path, "#{object_name}.yaml")
+        object_kind = o.dig("kind").downcase
+        target_file = File.join(path, "#{object_name}-#{object_kind}.yaml")
         write_to_file(target_file: target_file, object: o)
       end
     end

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -1,0 +1,13 @@
+# typed: strict
+require 'forwardable'
+
+module Splat
+  def sort_into_namespaces(arr)
+    binding.pry
+  end
+
+  def write_namespaces_into_folder(namespaces_arr:, target_dir:)
+    binding.pry
+  end
+end
+

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -4,62 +4,65 @@ require 'fileutils'
 require 'yaml'
 
 module Splat
-  module_function
-  def sort_into_namespaces(arr)
-    arr.group_by {|o| o.dig("metadata", "namespace")}
-  end
-
-  def mkdirp(p)
-    FileUtils.mkdir_p(p)
-  end
-
-  def safe_path_ref(target_dir:, namespace:)
-    path = if namespace.nil?
-             target_dir
-           else
-             File.join(target_dir,namespace)
-           end
-    mkdirp(path); path
-  end
-
-  def abort_if_missing_kind(object)
-    o = object.dig("kind")
-    if o.nil? || (o&.length == 0)
-      raise StandardError,
-        "Kubernetes YAML resources cannot be missing apiVersion or kind"
+  # module_function -- ackshually https://stackoverflow.com/a/35012552/661659
+  class << self
+    def sort_into_namespaces(arr)
+      arr.group_by {|o| o.dig("metadata", "namespace")}
     end
-  end
 
-  def abort_if_missing_name(object)
-    o = object.dig("metadata","name")
-    if o.nil? || (o&.length == 0)
-      raise StandardError,
-        "Kubernetes YAML resources cannot be missing metadata.name"
-    end
-  end
+    def write_namespaces_into_folder(namespaces_arr:, target_dir:)
+      # validate first
+      namespaces_arr.values.flatten.map{|o|
+        abort_if_missing_kind(o)
+        abort_if_missing_name(o)
+      }
 
-  def write_namespaces_into_folder(namespaces_arr:, target_dir:)
-    # validate first
-    namespaces_arr.values.flatten.map{|o|
-      abort_if_missing_kind(o)
-      abort_if_missing_name(o)
-    }
+      # write everything out into folders
+      namespaces_arr.each do |namespace, arr|
+        path = safe_path_ref(target_dir:target_dir, namespace:namespace)
 
-    # write everything out into folders
-    namespaces_arr.each do |namespace, arr|
-      path = safe_path_ref(target_dir:target_dir, namespace:namespace)
-
-      arr.each do |o|
-        object_name = o.dig("metadata", "name")
-        object_kind = o.dig("kind").downcase
-        target_file = File.join(path, "#{object_name}-#{object_kind}.yaml")
-        write_to_file(target_file: target_file, object: o)
+        arr.each do |o|
+          object_name = o.dig("metadata", "name")
+          object_kind = o.dig("kind").downcase
+          target_file = File.join(path, "#{object_name}-#{object_kind}.yaml")
+          write_to_file(target_file: target_file, object: o)
+        end
       end
     end
-  end
 
-  def write_to_file(target_file:, object:)
-    File.open(target_file, 'w') { |file| file.write(object.to_yaml) }
+    private
+
+    def mkdirp(p)
+      FileUtils.mkdir_p(p)
+    end
+
+    def safe_path_ref(target_dir:, namespace:)
+      path = if namespace.nil?
+               target_dir
+             else
+               File.join(target_dir,namespace)
+             end
+      mkdirp(path); path
+    end
+
+    def abort_if_missing_kind(object)
+      o = object.dig("kind")
+      if o.nil? || (o&.length == 0)
+        raise StandardError,
+          "Kubernetes YAML resources cannot be missing apiVersion or kind"
+      end
+    end
+
+    def abort_if_missing_name(object)
+      o = object.dig("metadata","name")
+      if o.nil? || (o&.length == 0)
+        raise StandardError,
+          "Kubernetes YAML resources cannot be missing metadata.name"
+      end
+    end
+
+    def write_to_file(target_file:, object:)
+      File.open(target_file, 'w') { |file| file.write(object.to_yaml) }
+    end
   end
 end
-

--- a/lib/splat/splat.rb
+++ b/lib/splat/splat.rb
@@ -9,10 +9,23 @@ module Splat
     arr.group_by {|o| o.dig("metadata", "namespace")}
   end
 
+  def mkdirp(p)
+    FileUtils.mkdir_p(p)
+  end
+
+  def safe_path_ref(target_dir:, namespace:)
+    path = if namespace.nil?
+             target_dir
+           else
+             File.join(target_dir,namespace)
+           end
+    mkdirp(path); path
+  end
+
   def write_namespaces_into_folder(namespaces_arr:, target_dir:)
     namespaces_arr.each do |namespace, arr|
-      path = File.join(target_dir,namespace)
-      FileUtils.mkdir_p path
+      path = safe_path_ref(target_dir:target_dir, namespace:namespace)
+
       arr.each do |o|
         object_name = o.dig("metadata", "name")
         target_file = File.join(path, "#{object_name}.yaml")

--- a/spec/splat/splat_spec.rb
+++ b/spec/splat/splat_spec.rb
@@ -19,40 +19,52 @@ RSpec.describe Splat do
   end
 
   describe '#write_namespaces_into_folder' do
-    context 'namespaced content' do
+    context 'namespaced content missing Kind' do
       let(:t) {
         {"foo"=>[{"metadata"=>{"namespace"=>"foo", "name"=>"foo"}}],
          "bar"=>[{"metadata"=>{"namespace"=>"bar", "name"=>"foo"}}]}
       }
+      it 'fails' do
+        expect {
+          Splat.write_namespaces_into_folder(
+            namespaces_arr: t, target_dir: 'test-tmp-dir')
+        }.to raise_error(StandardError, "Kubernetes YAML resources cannot be missing apiVersion or kind")
+      end
+    end
+    context 'namespaced content, properly formed' do
+      let(:t) {
+        {"foo"=>[{"metadata"=>{"namespace"=>"foo", "name"=>"foo"}, "apiVersion"=>"v1", "kind"=>"Whatever"}],
+         "bar"=>[{"metadata"=>{"namespace"=>"bar", "name"=>"foo"}, "apiVersion"=>"v1", "kind"=>"Whatever"}]}
+      }
       it 'works' do
         allow(Splat).to receive(:mkdirp)
         expect(Splat).to receive(:write_to_file).with(
-          :object=>{"metadata"=>{"name"=>"foo", "namespace"=>"foo"}},
-          :target_file=>"test-tmp-dir/foo/foo.yaml"
+          :object=>{"metadata"=>{"name"=>"foo","namespace"=>"foo"},"apiVersion"=>"v1","kind"=>"Whatever"},
+          :target_file=>"test-tmp-dir/foo/foo-whatever.yaml"
         ).ordered
         expect(Splat).to receive(:write_to_file).with(
-          :object=>{"metadata"=>{"name"=>"foo", "namespace"=>"bar"}},
-          :target_file=>"test-tmp-dir/bar/foo.yaml"
+          :object=>{"metadata"=>{"name"=>"foo","namespace"=>"bar"},"apiVersion"=>"v1","kind"=>"Whatever"},
+          :target_file=>"test-tmp-dir/bar/foo-whatever.yaml"
         ).ordered
 
         r = Splat.write_namespaces_into_folder(
           namespaces_arr: t, target_dir: 'test-tmp-dir')
       end
     end
-    context 'unnamespaced content' do
+    context 'unnamespaced content, properly formed' do
       let(:t) {
-        {nil=>[{"metadata"=>{"name"=>"foo"}},
-               {"metadata"=>{"name"=>"bar"}}]}
+        {nil=>[{"metadata"=>{"name"=>"foo"}, "apiVersion"=>"v1", "kind"=>"Whatever"},
+               {"metadata"=>{"name"=>"bar"}, "apiVersion"=>"v1", "kind"=>"Whatever"}]}
       }
       it 'works' do
         allow(Splat).to receive(:mkdirp)
         expect(Splat).to receive(:write_to_file).with(
-          :object=>{"metadata"=>{"name"=>"foo"}},
-          :target_file=>"test-tmp-dir/foo.yaml"
+          :object=>{"metadata"=>{"name"=>"foo"},"apiVersion"=>"v1","kind"=>"Whatever"},
+          :target_file=>"test-tmp-dir/foo-whatever.yaml"
         ).ordered
         expect(Splat).to receive(:write_to_file).with(
-          :object=>{"metadata"=>{"name"=>"bar"}},
-          :target_file=>"test-tmp-dir/bar.yaml"
+          :object=>{"metadata"=>{"name"=>"bar"},"apiVersion"=>"v1","kind"=>"Whatever"},
+          :target_file=>"test-tmp-dir/bar-whatever.yaml"
         ).ordered
 
         r = Splat.write_namespaces_into_folder(

--- a/spec/splat/splat_spec.rb
+++ b/spec/splat/splat_spec.rb
@@ -1,0 +1,63 @@
+require './lib/splat/splat'
+# Splat.write_namespaces_into_folder(
+#   target_dir: './secrets',
+#   namespaces_arr: Splat.sort_into_namespaces(secrets))
+
+require 'pry'
+
+RSpec.describe Splat do
+  describe '#sort_into_namespaces' do
+    it 'groups by namespace' do
+      t = [{"metadata"=> {"namespace"=> "foo"}}, {"metadata"=> {"namespace"=> "bar"}}]
+      r = Splat.sort_into_namespaces(t)
+      expect(r.keys).to eq(['foo', 'bar'])
+    end
+
+    it 'puts unnamespaced things into a separate bin' do
+      t = [{"metadata"=> {"name"=> "foo"}}, {"metadata"=> {"name"=> "bar"}}]
+      r = Splat.sort_into_namespaces(t)
+      expect(r.keys).to eq([nil])
+    end
+  end
+
+  describe '#write_namespaces_into_folder' do
+    context 'namespaced content' do
+      let(:t) {
+        {"foo"=>[{"metadata"=>{"namespace"=>"foo", "name"=>"foo"}}],
+         "bar"=>[{"metadata"=>{"namespace"=>"bar", "name"=>"foo"}}]}
+      }
+      it 'works' do
+        expect(Splat).to receive(:write_to_file).with(
+          :object=>{"metadata"=>{"name"=>"foo", "namespace"=>"foo"}},
+          :target_file=>"test-tmp-dir/foo/foo.yaml"
+        ).ordered
+        expect(Splat).to receive(:write_to_file).with(
+          :object=>{"metadata"=>{"name"=>"foo", "namespace"=>"bar"}},
+          :target_file=>"test-tmp-dir/bar/foo.yaml"
+        ).ordered
+
+        r = Splat.write_namespaces_into_folder(
+          namespaces_arr: t, target_dir: 'test-tmp-dir')
+      end
+    end
+    context 'unnamespaced content' do
+      let(:t) {
+        {nil=>[{"metadata"=>{"name"=>"foo"}}],
+         nil=>[{"metadata"=>{"name"=>"foo"}}]}
+      }
+      it 'works' do
+        expect(Splat).to receive(:write_to_file).with(
+          :object=>{"metadata"=>{"name"=>"foo"}},
+          :target_file=>"test-tmp-dir/foo.yaml"
+        ).ordered
+        expect(Splat).to receive(:write_to_file).with(
+          :object=>{"metadata"=>{"name"=>"foo"}},
+          :target_file=>"test-tmp-dir/foo.yaml"
+        ).ordered
+
+        r = Splat.write_namespaces_into_folder(
+          namespaces_arr: t, target_dir: 'test-tmp-dir')
+      end
+    end
+  end
+end

--- a/spec/splat/splat_spec.rb
+++ b/spec/splat/splat_spec.rb
@@ -3,8 +3,6 @@ require './lib/splat/splat'
 #   target_dir: './secrets',
 #   namespaces_arr: Splat.sort_into_namespaces(secrets))
 
-require 'pry'
-
 RSpec.describe Splat do
   describe '#sort_into_namespaces' do
     it 'groups by namespace' do
@@ -27,6 +25,7 @@ RSpec.describe Splat do
          "bar"=>[{"metadata"=>{"namespace"=>"bar", "name"=>"foo"}}]}
       }
       it 'works' do
+        allow(Splat).to receive(:mkdirp)
         expect(Splat).to receive(:write_to_file).with(
           :object=>{"metadata"=>{"name"=>"foo", "namespace"=>"foo"}},
           :target_file=>"test-tmp-dir/foo/foo.yaml"
@@ -42,17 +41,18 @@ RSpec.describe Splat do
     end
     context 'unnamespaced content' do
       let(:t) {
-        {nil=>[{"metadata"=>{"name"=>"foo"}}],
-         nil=>[{"metadata"=>{"name"=>"foo"}}]}
+        {nil=>[{"metadata"=>{"name"=>"foo"}},
+               {"metadata"=>{"name"=>"bar"}}]}
       }
       it 'works' do
+        allow(Splat).to receive(:mkdirp)
         expect(Splat).to receive(:write_to_file).with(
           :object=>{"metadata"=>{"name"=>"foo"}},
           :target_file=>"test-tmp-dir/foo.yaml"
         ).ordered
         expect(Splat).to receive(:write_to_file).with(
-          :object=>{"metadata"=>{"name"=>"foo"}},
-          :target_file=>"test-tmp-dir/foo.yaml"
+          :object=>{"metadata"=>{"name"=>"bar"}},
+          :target_file=>"test-tmp-dir/bar.yaml"
         ).ordered
 
         r = Splat.write_namespaces_into_folder(

--- a/split-builder.rb
+++ b/split-builder.rb
@@ -45,12 +45,12 @@ if 0 == @last_exit_status && @stderr == ""
   cluster_issuers = ''
 
   # Write the secret files out
-  write_namespaces_into_folder(target_dir: './secrets',
-    namespaces_arr: sort_into_namespaces(secrets))
+  Splat.write_namespaces_into_folder(target_dir: './secrets',
+    namespaces_arr: Splat.sort_into_namespaces(secrets))
 
   # Write the manifest files out
-  write_namespaces_into_folder(target_dir: './manifests/k8s',
-    namespaces_arr: sort_into_namespaces(manifests))
+  Splat.write_namespaces_into_folder(target_dir: './manifests/k8s',
+    namespaces_arr: Splat.sort_into_namespaces(manifests))
 else
   puts @stderr
   Kernel.exit(@last_exit_status)

--- a/split-builder.rb
+++ b/split-builder.rb
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+# builder.rb - generate k8s.yml in manifests/
+
+require 'yaml'
+require './lib/splat/splat'
+
+command = 'bundle exec kuby -e production resources'
+
+# from: https://coderedirect.com/questions/353836/fork-child-process-with-timeout-and-capture-output
+array = []
+
+# stdout, stderr pipes
+rout, wout = IO.pipe
+rerr, werr = IO.pipe
+
+pid = Process.spawn(command, :out => wout, :err => werr)
+_, status = Process.wait2(pid)
+
+# close write ends so we could read them
+wout.close
+werr.close
+
+@stdout = rout.readlines.join
+@stderr = rerr.readlines.join
+
+# dispose the read ends of the pipes
+rout.close
+rerr.close
+
+@last_exit_status = status.exitstatus
+
+if 0 == @last_exit_status && @stderr == ""
+  YAML.load_stream(@stdout) { |doc| array << doc }
+
+  # Filter any secrets and regular manifests into separate partitions
+  secrets, manifests = array.partition { |x| x["kind"] == "Secret" }
+
+  cluster_issuers, manifests =
+    manifests.partition do |x|
+      x["kind"] == "ClusterIssuer" ||
+        x["kind"] == "Namespace"
+    end
+
+  # Discard the cluster issuer since we will be operating as a tenant
+  cluster_issuers = ''
+
+  # Write the secret files out
+  write_namespaces_into_folder(target_dir: './secrets',
+    namespaces_arr: sort_into_namespaces(secrets))
+
+  # Write the manifest files out
+  write_namespaces_into_folder(target_dir: './manifests/k8s',
+    namespaces_arr: sort_into_namespaces(manifests))
+else
+  puts @stderr
+  Kernel.exit(@last_exit_status)
+end


### PR DESCRIPTION
With an input stream of YAML documents, let's create a directory structure of the shape under `manifests`:

```
k8s
└── scrob-production
    ├── scrob-assets-deployment.yaml
    ├── scrob-assets-nginx-config-configmap.yaml
    ├── scrob-assets-sa-serviceaccount.yaml
    ├── scrob-assets-svc-service.yaml
    ├── scrob-config-configmap.yaml
    ├── scrob-ingress-ingress.yaml
    ├── scrob-sa-serviceaccount.yaml
    ├── scrob-svc-service.yaml
    └── scrob-web-deployment.yaml
```

This is the directory structure that I would choose for optimum patch readability when a PR is being submitted...

(aside: if you're coming here from the Discussion link, to provide some context: "scrob-production" is the namespace and `scrob-assets` or `scrob-web` are the name of most of the resources in the Scrob project. We were generating a file `k8s.yml` before. Now we'd like to generate a directory structure with one singular resource YAML doc in each file instead.)

...for optimum readability, of changes to the generated manifest builder source input. There are other problems to addres first before using this in a real production scenario, but I wanted to spec the whole algorithm and prove out a spec with a basic MVP implementation of this basic before getting bogged down with those harder ideas.

Namely: if we use the split-builder instead of the original (`builder.rb`), then our manifest tree will not be a single file `k8s.yaml` anymore, but instead a collection of files and folders representing namespaces and files named for each resource name and kind. (So we will need to consider garbage collection, and then we will need to consider adding special health checks or other protections to avoid a garbage collection driven catastrophe from accidental garbage collection.)

I think I won't be using this in a CI pipeline any time soon, so I'm comfortable merging this and calling it a solution without bothering that issue! But I promised I'd write something by this weekend at the latest, so here it is.

```
Splat
  #sort_into_namespaces
    groups by namespace
    puts unnamespaced things into a separate bin
  #write_namespaces_into_folder
    namespaced content missing Kind
      fails
    namespaced content, properly formed
      works
    unnamespaced content, properly formed
      works

Finished in 0.00396 seconds (files took 0.07775 seconds to load)
5 examples, 0 failures
```