### PR TITLE
Test Kuby with ruby version 3.1.3

### DIFF
--- a/.github/workflows/kuby.yml
+++ b/.github/workflows/kuby.yml
@@ -9,7 +9,7 @@ jobs:
     name: Image Builder
     runs-on: self-hosted
     env:
-      RUBY_VERSION: 3.1.2
+      RUBY_VERSION: 3.1.3
 
     steps:
     - uses: actions/checkout@v2
@@ -69,7 +69,7 @@ jobs:
     runs-on: self-hosted
     needs: builder
     env:
-      RUBY_VERSION: 3.1.2
+      RUBY_VERSION: 3.1.3
 
     steps:
       - name: Prepare


### PR DESCRIPTION
There were a lot of gems updated since we last tested this

The objective here is to figure out which line of code names the `ClusterIssuer` and change it to the one we prefer

(There are two valid clusterissuers:

* `letsencrypt-production` - this is under `moo-cluster`, alongside of `example-clusterissuer` the staging issuer
* `production-letsencrypt` - this is on the host cluster, will be shown as `loft_loft-cluster` on the architecture diagrams
We mean to do away with the first one, and keep the second one around.)

The anti-pattern is managing cluster services inside of a vcluster. You can do this, but just because you can doesn't mean you should? In our case, the cluster is a "staging" cluster but it hosts production services, this is a mis-architecture without any excuse. "We didn't think they'd become production services so quickly"

Because ingress resources are managed with ingress controllers on the host cluster, we don't need ingress controllers on each vcluster. The vcluster definition permits ingresses to be copied from the child cluster to the parent, and satisfied by those ingressclasses that are already hosted on the parent cluster:

```
$ kg ingressclass
NAME       CONTROLLER                      PARAMETERS   AGE
internal   k8s.io/ingress-nginx-internal   <none>       89d
nginx      k8s.io/ingress-nginx            <none>       29d
public     k8s.io/ingress-nginx-public     <none>       89d
traefik    traefik.io/ingress-controller   <none>       88d
```

https://github.com/kingdonb/vcluster-moo-cluster/blob/da2b95ff0a052a6b2407ca5eb7b59a9ba86b34b8/vclusters/vcluster-moo-cluster.yaml#L47-L48

The child need not redefine those ingress classes locally, or it can re-define them, but as long as they are copied to the host cluster, the definitions inside of the vcluster are just for show. The actual effective ingress definition is on the host cluster. (It's also possible for leaf clusters to define their own ingressclasses and have them copied to the host cluster, but there are certainly some limits on what else we can demonstrate without being accused of showing off!)

A secondary benefit of this configuration, if you see it as a benefit, is that TLS ingresses are effective without granting access to the TLS cert to any namespaced processes that are hosted in the namespace. The cluster issuer in the host cluster prepares a secret and sets up the HTTP-01 challenge, all outside of the guest cluster, and the cluster tenant never has an opportunity to handle the TLS secret directly, so never in a position to make a mistake and compromise the secret.

That all does not have much to do with Kuby, however context 🙃 👍 